### PR TITLE
urlがexample.comになっていたのを修正

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,6 @@ import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://example.com',
-	integrations: [mdx(), sitemap()],
+  site: 'https://monochrome0209.github.io/',
+  integrations: [mdx(), sitemap()],
 });


### PR DESCRIPTION
# 概要

<!-- IssueのURLを記載してください -->

デプロイ先が`example.com`になっていたため、正しくデプロイできるものへ修正

[※参考](https://docs.astro.build/ja/guides/deploy/github/)
